### PR TITLE
Discord server nuke notice

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,8 +9,12 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="fractions.css">
     </head>
+<script>
+    window.onload = function() {
+  alert("THE DISCORD SERVER WAS NUKED. PLEASE REJOIN AT DISCORD.GG/NOWGG");
+};
+    </script>
         <iframe src="main.html"></iframe>
-
     </body>
     <script src="worksheets/api/lod.js"></script>
 </html>


### PR DESCRIPTION
Adds a javascript alert to show users the Discord server was nuked with the invite link to rejoin. (dw i tested it, it doesnt break anything.) 